### PR TITLE
null pointer error fix if event meta data is null

### DIFF
--- a/src/main/java/com/client/core/scheduledtasks/model/helper/CustomSubscriptionEvent.java
+++ b/src/main/java/com/client/core/scheduledtasks/model/helper/CustomSubscriptionEvent.java
@@ -47,8 +47,10 @@ public class CustomSubscriptionEvent{
             customSubscriptionEvent.setUpdatedProperties(Sets.newHashSet());
         }
 
-        if(event.getEventMetadata().containsKey("PERSON_ID")){
-            customSubscriptionEvent.setUpdatingUserId(Integer.parseInt(event.getEventMetadata().get("PERSON_ID")));
+        if (event.getEventMetadata() != null) {
+            if (event.getEventMetadata().containsKey("PERSON_ID")) {
+                customSubscriptionEvent.setUpdatingUserId(Integer.parseInt(event.getEventMetadata().get("PERSON_ID")));
+            }
         }
 
         return customSubscriptionEvent;


### PR DESCRIPTION
For some reason, not all subscription events contain eventMetadata, which causing java.lang.NullPointerException in events processing and skipping whole events batch.
Details are in this [JIRA](https://jira.bullhorn.com/browse/PS-9249?focusedCommentId=857955&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-857955).