### PR TITLE
Utility.valueChanged integers comparison fix

### DIFF
--- a/src/main/java/com/client/core/base/util/Utility.java
+++ b/src/main/java/com/client/core/base/util/Utility.java
@@ -52,96 +52,98 @@ import com.google.common.collect.Lists;
 
 public class Utility {
 
-	public static Map<? extends BullhornRelatedEntity, Set<String>> getRequestedFields(BullhornRelatedEntity[] relatedEntities,
-																					   List<? extends WorkflowAction<?, ?>> actions) {
-		Map<? extends BullhornRelatedEntity, Set<String>> requestedFields = actions.stream().map(WorkflowAction::getRelatedEntityFields).reduce(Maps.newLinkedHashMap(), (firstMap, secondMap) -> {
-			return Stream.concat(firstMap.entrySet().stream(), secondMap.entrySet().stream())
-					.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue,
-							Utility::mergeFieldSets));
-		});
+    public static Map<? extends BullhornRelatedEntity, Set<String>> getRequestedFields(BullhornRelatedEntity[] relatedEntities,
+                                                                                       List<? extends WorkflowAction<?, ?>> actions) {
+        Map<? extends BullhornRelatedEntity, Set<String>> requestedFields = actions.stream().map(WorkflowAction::getRelatedEntityFields).reduce(Maps.newLinkedHashMap(), (firstMap, secondMap) -> {
+            return Stream.concat(firstMap.entrySet().stream(), secondMap.entrySet().stream())
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue,
+                            Utility::mergeFieldSets));
+        });
 
-		return Stream.concat(Stream.of(relatedEntities), Stream.of(StandardRelatedEntity.values())).collect(Collectors.toMap(Function.identity(), relatedEntity -> {
-			if (requestedFields.containsKey(relatedEntity)) {
-				return Utility.mergeFieldSets(relatedEntity.getDefaultFields(), requestedFields.get(relatedEntity));
-			}
+        return Stream.concat(Stream.of(relatedEntities), Stream.of(StandardRelatedEntity.values())).collect(Collectors.toMap(Function.identity(), relatedEntity -> {
+            if (requestedFields.containsKey(relatedEntity)) {
+                return Utility.mergeFieldSets(relatedEntity.getDefaultFields(), requestedFields.get(relatedEntity));
+            }
 
-			return relatedEntity.getDefaultFields();
-		}));
-	}
+            return relatedEntity.getDefaultFields();
+        }));
+    }
 
-	public static Set<String> mergeFieldSets(Set<String> set1, Set<String> set2) {
-		return mergeNestedFields(Sets.union(set1, set2));
-	}
+    public static Set<String> mergeFieldSets(Set<String> set1, Set<String> set2) {
+        return mergeNestedFields(Sets.union(set1, set2));
+    }
 
-	public static Set<String> mergeNestedFields(Set<String> fields) {
-		return fields.parallelStream().map(field -> {
-			return field.replaceAll("\\s+", "");
-		}).collect(Collectors.groupingBy(field -> {
-			return StringUtils.substringBefore(field, "(").trim();
-		})).entrySet().parallelStream().map(entry -> {
-			if (entry.getValue().size() == 1) {
-				return entry.getValue().get(0).trim();
-			} else {
-				Set<String> nestedFields = entry.getValue().parallelStream().map(nestedField -> {
-					return StringUtils.substringBeforeLast(StringUtils.substringAfter(nestedField, "("), ")");
-				}).flatMap(nestedField -> {
-					return splitOutsideParentheses(nestedField).stream();
-				}).collect(Collectors.toSet());
+    public static Set<String> mergeNestedFields(Set<String> fields) {
+        return fields.parallelStream().map(field -> {
+            return field.replaceAll("\\s+", "");
+        }).collect(Collectors.groupingBy(field -> {
+            return StringUtils.substringBefore(field, "(").trim();
+        })).entrySet().parallelStream().map(entry -> {
+            if (entry.getValue().size() == 1) {
+                return entry.getValue().get(0).trim();
+            } else {
+                Set<String> nestedFields = entry.getValue().parallelStream().map(nestedField -> {
+                    return StringUtils.substringBeforeLast(StringUtils.substringAfter(nestedField, "("), ")");
+                }).flatMap(nestedField -> {
+                    return splitOutsideParentheses(nestedField).stream();
+                }).collect(Collectors.toSet());
 
-				return mergeNestedFields(nestedFields).parallelStream().collect(Collectors.joining(",", entry.getKey() + "(", ")"));
-			}
-		}).collect(Collectors.toSet());
-	}
+                return mergeNestedFields(nestedFields).parallelStream().collect(Collectors.joining(",", entry.getKey() + "(", ")"));
+            }
+        }).collect(Collectors.toSet());
+    }
 
-	public static Set<String> splitOutsideParentheses(String value) {
-		Set<String> result = Sets.newHashSet();
+    public static Set<String> splitOutsideParentheses(String value) {
+        Set<String> result = Sets.newHashSet();
 
-		StringBuilder current = new StringBuilder();
-		Integer isParenthesis = 0;
+        StringBuilder current = new StringBuilder();
+        Integer isParenthesis = 0;
 
-		for(Integer index = 0; index < value.length(); index++) {
-			if (value.charAt(index) == '(') {
-				isParenthesis++;
-				current.append('(');
-			} else if (value.charAt(index) == ')' && isParenthesis > 0) {
-				isParenthesis--;
-				current.append(')');
-			} else if (value.charAt(index) == ',' && isParenthesis == 0) {
-				result.add(current.toString());
-				current = new StringBuilder();
-			} else {
-				current.append(value.charAt(index));
-			}
-		}
+        for (Integer index = 0; index < value.length(); index++) {
+            if (value.charAt(index) == '(') {
+                isParenthesis++;
+                current.append('(');
+            } else if (value.charAt(index) == ')' && isParenthesis > 0) {
+                isParenthesis--;
+                current.append(')');
+            } else if (value.charAt(index) == ',' && isParenthesis == 0) {
+                result.add(current.toString());
+                current = new StringBuilder();
+            } else {
+                current.append(value.charAt(index));
+            }
+        }
 
-		if (StringUtils.isNotBlank(current)) {
-			result.add(current.toString());
-		}
+        if (StringUtils.isNotBlank(current)) {
+            result.add(current.toString());
+        }
 
-		return result;
-	}
+        return result;
+    }
 
-	public static boolean isNumbersOnly(String str) {
-		if (str == null || str.isEmpty()) {
-			return false;
-		}
-		for (int i = 0; i < str.length(); i++) {
-			if (!Character.isDigit(str.charAt(i)))
-				return false;
-		}
-		return true;
-	}
+    public static boolean isNumbersOnly(String str) {
+        if (str == null || str.isEmpty()) {
+            return false;
+        }
+        for (int i = 0; i < str.length(); i++) {
+            if (!Character.isDigit(str.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
 
-	public static boolean isNumeric(String value) {
-		if (value == null || value.isEmpty()) {
-			return false;
-		}
-		for (int i = 0; i < value.length(); i++) {
-			if (!Character.isDigit(value.charAt(i)) && !".".equalsIgnoreCase(Character.toString(value.charAt(i))))
-				return false;
-		}
-		return true;
-	}
+    public static boolean isNumeric(String value) {
+        if (value == null || value.isEmpty()) {
+            return false;
+        }
+        for (int i = 0; i < value.length(); i++) {
+            if (!Character.isDigit(value.charAt(i)) && !".".equalsIgnoreCase(Character.toString(value.charAt(i)))) {
+                return false;
+            }
+        }
+        return true;
+    }
 
     public static Set<Integer> parseCommaSeparatedIntegers(String value) {
         return parseCommaSeparated(value, Utility::forceParseInteger);
@@ -159,14 +161,14 @@ public class Utility {
         R oldValue = get.apply(oldEntity);
         R newValue = get.apply(newEntity);
 
-        if(oldValue instanceof Address) {
+        if (oldValue instanceof Address) {
             return valueChanged((Address) oldEntity, (Address) newEntity, Address::getAddress1)
                     || valueChanged((Address) oldEntity, (Address) newEntity, Address::getAddress2)
                     || valueChanged((Address) oldEntity, (Address) newEntity, Address::getCity)
                     || valueChanged((Address) oldEntity, (Address) newEntity, Address::getState)
                     || valueChanged((Address) oldEntity, (Address) newEntity, Address::getZip)
                     || valueChanged((Address) oldEntity, (Address) newEntity, Address::getCountryID);
-        } else if(oldValue instanceof BullhornEntity) {
+        } else if (oldValue instanceof BullhornEntity) {
             return valueChanged((BullhornEntity) oldValue, (BullhornEntity) newValue, BullhornEntity::getId);
         }
 
@@ -174,22 +176,22 @@ public class Utility {
     }
 
     public static <T> Boolean valueChanged(T oldValue, T newValue) {
-        if(oldValue == null) {
+        if (oldValue == null) {
             return newValue != null;
-        } else if(newValue == null) {
+        } else if (newValue == null) {
             return true;
-        } else if(oldValue instanceof String) {
-            String oldString = StringUtils.defaultIfBlank((String)oldValue, "");
-            String newString = StringUtils.defaultIfBlank((String)newValue, "");
+        } else if (oldValue instanceof String) {
+            String oldString = StringUtils.defaultIfBlank((String) oldValue, "");
+            String newString = StringUtils.defaultIfBlank((String) newValue, "");
 
             return !oldString.equals(newString);
-        } else if(oldValue instanceof Boolean || oldValue instanceof Integer) {
+        } else if (oldValue instanceof Boolean || oldValue instanceof Integer) {
             return oldValue != newValue;
-        } else if(oldValue instanceof BigDecimal) {
+        } else if (oldValue instanceof BigDecimal) {
             return ((BigDecimal) oldValue).compareTo((BigDecimal) newValue) != 0;
-        } else if(oldValue instanceof DateTime) {
+        } else if (oldValue instanceof DateTime) {
             return Days.daysBetween((DateTime) oldValue, (DateTime) newValue).getDays() != 0;
-        } else if(oldValue instanceof BullhornEntity) {
+        } else if (oldValue instanceof BullhornEntity) {
             return valueChanged((BullhornEntity) oldValue, (BullhornEntity) newValue, BullhornEntity::getId);
         }
 
@@ -210,22 +212,22 @@ public class Utility {
         return value.replaceAll("'", "''");
     }
 
-	public static Map<String, String> commaDelimitedStringToMap(String commaDelimited) {
-		List<String> parsed = Arrays.asList(commaDelimited.split(","));
-		Map<String, String> theMap = new LinkedHashMap<String, String>();
+    public static Map<String, String> commaDelimitedStringToMap(String commaDelimited) {
+        List<String> parsed = Arrays.asList(commaDelimited.split(","));
+        Map<String, String> theMap = new LinkedHashMap<String, String>();
 
-		for(String value : parsed) {
-			theMap.put(value, value);
-		}
+        for (String value : parsed) {
+            theMap.put(value, value);
+        }
 
-		return theMap;
-	}
+        return theMap;
+    }
 
-	public static void combineJsonArrays(JSONArray jsonArray1, JSONArray jsonArray2) {
-		IntStream.range(0, jsonArray2.length()).forEach(index -> {
-			jsonArray1.put(jsonArray2.get(index));
-		});
-	}
+    public static void combineJsonArrays(JSONArray jsonArray1, JSONArray jsonArray2) {
+        IntStream.range(0, jsonArray2.length()).forEach(index -> {
+            jsonArray1.put(jsonArray2.get(index));
+        });
+    }
 
     public static <T> Predicate<T> distinctByKey(Function<? super T, Object> keyExtractor) {
         Map<Object, Boolean> seen = new ConcurrentHashMap<>();
@@ -233,346 +235,345 @@ public class Utility {
         return t -> seen.putIfAbsent(keyExtractor.apply(t), Boolean.TRUE) == null;
     }
 
-	public static Boolean isPositive(Integer value) {
-	    return value != null && value > 0;
+    public static Boolean isPositive(Integer value) {
+        return value != null && value > 0;
     }
 
     public static Boolean isPositive(BigDecimal value) {
         return value != null && value.compareTo(BigDecimal.ZERO) > 0;
     }
 
-	public static Boolean isPositive(Object value) {
+    public static Boolean isPositive(Object value) {
         return isPositive(forceParseBigDecimal(value));
     }
 
-	public static BigDecimal parseBigDecimal(Object value) {
-		if(value == null || value.toString().isEmpty()) {
-			return null;
-		} else {
-			try {
-				Double check = Double.parseDouble(value.toString());
-
-				return new BigDecimal(check);
-			} catch(NumberFormatException e) {
-				return null;
-			}
-		}
-	}
-
-	public static BigDecimal forceParseBigDecimal(Object value) {
-		if(value == null || value.toString().isEmpty()) {
-			return BigDecimal.ZERO;
-		} else {
-			try {
-				Double check = Double.parseDouble(value.toString());
-
-				return new BigDecimal(check);
-			} catch(NumberFormatException e) {
-				return BigDecimal.ZERO;
-			}
-		}
-	}
-
-    public static Integer parseInteger(Object value) {
-        if(value == null || value.toString().isEmpty()) {
+    public static BigDecimal parseBigDecimal(Object value) {
+        if (value == null || value.toString().isEmpty()) {
             return null;
         } else {
             try {
-                return Integer.parseInt(value.toString());
-            } catch(NumberFormatException e) {
+                Double check = Double.parseDouble(value.toString());
+
+                return new BigDecimal(check);
+            } catch (NumberFormatException e) {
                 return null;
             }
         }
     }
 
-	public static Integer forceParseInteger(Object value) {
-		if(value == null || value.toString().isEmpty()) {
-			return 0;
-		} else {
-			try {
-				return Integer.parseInt(value.toString());
-			} catch(NumberFormatException e) {
-				return 0;
-			}
-		}
-	}
+    public static BigDecimal forceParseBigDecimal(Object value) {
+        if (value == null || value.toString().isEmpty()) {
+            return BigDecimal.ZERO;
+        } else {
+            try {
+                Double check = Double.parseDouble(value.toString());
 
-	public static Double parseDouble(Object value) {
-		if(value == null || value.toString().isEmpty()) {
-			return null;
-		}else {
-			try {
-				return Double.parseDouble(value.toString());
-			} catch(NumberFormatException e) {
-				return null;
-			}
-		}
-	}
+                return new BigDecimal(check);
+            } catch (NumberFormatException e) {
+                return BigDecimal.ZERO;
+            }
+        }
+    }
 
-	public static Double forceParseDouble(Object value) {
-		if(value == null || value.toString().isEmpty()) {
-			return 0D;
-		}else {
-			try {
-				return Double.parseDouble(value.toString());
-			} catch(NumberFormatException e) {
-				return 0D;
-			}
-		}
-	}
+    public static Integer parseInteger(Object value) {
+        if (value == null || value.toString().isEmpty()) {
+            return null;
+        } else {
+            try {
+                return Integer.parseInt(value.toString());
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
+    }
 
-	public static Long forceParseLong(Object value) {
-		if(value == null || value.toString().isEmpty()) {
-			return 0L;
-		} else {
-			try {
-				return Long.parseLong(value.toString());
-			} catch(NumberFormatException e) {
-				return 0L;
-			}
-		}
-	}
+    public static Integer forceParseInteger(Object value) {
+        if (value == null || value.toString().isEmpty()) {
+            return 0;
+        } else {
+            try {
+                return Integer.parseInt(value.toString());
+            } catch (NumberFormatException e) {
+                return 0;
+            }
+        }
+    }
 
-	public static BigInteger forceParseBigInteger(Object value) {
-		if(value == null || value.toString().isEmpty()) {
-			return new BigInteger("0");
-		} else {
-			try {
-				return new BigInteger(value.toString());
-			} catch(NumberFormatException e) {
-				return new BigInteger("0");
-			}
-		}
-	}
+    public static Double parseDouble(Object value) {
+        if (value == null || value.toString().isEmpty()) {
+            return null;
+        } else {
+            try {
+                return Double.parseDouble(value.toString());
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
+    }
 
-	public static  Date parseStringToDate(String dateStr, String dateFormat) {
-		if(dateStr == null || dateStr.isEmpty() || dateFormat == null || dateFormat.isEmpty()) {
-			return null;
-		} else {
-			DateFormat format = new SimpleDateFormat(dateFormat);
-			try {
-				return format.parse(dateStr);
-			} catch(ParseException e) {
-				return null;
-			}
-		}
-	}
+    public static Double forceParseDouble(Object value) {
+        if (value == null || value.toString().isEmpty()) {
+            return 0D;
+        } else {
+            try {
+                return Double.parseDouble(value.toString());
+            } catch (NumberFormatException e) {
+                return 0D;
+            }
+        }
+    }
 
-	public static  Date forceParseStringToDate(String dateStr, String dateFormat) {
-		if(dateStr == null || dateStr.isEmpty() || dateFormat == null || dateFormat.isEmpty()) {
+    public static Long forceParseLong(Object value) {
+        if (value == null || value.toString().isEmpty()) {
+            return 0L;
+        } else {
+            try {
+                return Long.parseLong(value.toString());
+            } catch (NumberFormatException e) {
+                return 0L;
+            }
+        }
+    }
+
+    public static BigInteger forceParseBigInteger(Object value) {
+        if (value == null || value.toString().isEmpty()) {
+            return new BigInteger("0");
+        } else {
+            try {
+                return new BigInteger(value.toString());
+            } catch (NumberFormatException e) {
+                return new BigInteger("0");
+            }
+        }
+    }
+
+    public static Date parseStringToDate(String dateStr, String dateFormat) {
+        if (dateStr == null || dateStr.isEmpty() || dateFormat == null || dateFormat.isEmpty()) {
+            return null;
+        } else {
+            DateFormat format = new SimpleDateFormat(dateFormat);
+            try {
+                return format.parse(dateStr);
+            } catch (ParseException e) {
+                return null;
+            }
+        }
+    }
+
+    public static Date forceParseStringToDate(String dateStr, String dateFormat) {
+        if (dateStr == null || dateStr.isEmpty() || dateFormat == null || dateFormat.isEmpty()) {
             return DateTime.now().toDate();
-		} else {
-			TimeZone timeZone = TimeZone.getTimeZone("America/Detroit");
-			DateFormat format = new SimpleDateFormat(dateFormat);
-			format.setTimeZone(timeZone);
-			format.setLenient(false);
-			try {
-				return format.parse(dateStr);
-			} catch(ParseException e) {
-				return new Date(0);
-			}
-		}
-	}
+        } else {
+            TimeZone timeZone = TimeZone.getTimeZone("America/Detroit");
+            DateFormat format = new SimpleDateFormat(dateFormat);
+            format.setTimeZone(timeZone);
+            format.setLenient(false);
+            try {
+                return format.parse(dateStr);
+            } catch (ParseException e) {
+                return new Date(0);
+            }
+        }
+    }
 
-	public static DateTime parseStringToDateTime(String dateStr, String dateFormat) {
+    public static DateTime parseStringToDateTime(String dateStr, String dateFormat) {
 
 
-	    Date date = parseStringToDate(dateStr, dateFormat);
+        Date date = parseStringToDate(dateStr, dateFormat);
 
-	    if(date == null){
-	        return null;
-	    }
+        if (date == null) {
+            return null;
+        }
 
-		DateTime now = nowUsingTimeZone(null);
+        DateTime now = nowUsingTimeZone(null);
 
-		DateTime theCorrectDate = new DateTime(date,DateTimeZone.UTC);
-		theCorrectDate = theCorrectDate.plusHours(now.getHourOfDay());
-		theCorrectDate = theCorrectDate.plusMinutes(now.getMinuteOfHour());
-		return theCorrectDate;
-	}
+        DateTime theCorrectDate = new DateTime(date, DateTimeZone.UTC);
+        theCorrectDate = theCorrectDate.plusHours(now.getHourOfDay());
+        theCorrectDate = theCorrectDate.plusMinutes(now.getMinuteOfHour());
+        return theCorrectDate;
+    }
 
-	public static DateTimeZone defaultTimeZone() {
-		return DateTimeZone.forID("EST5EDT");
-	}
+    public static DateTimeZone defaultTimeZone() {
+        return DateTimeZone.forID("EST5EDT");
+    }
 
-	/**
-	 * Returns today based on time zone; defaults timeZone to "EST5EDT" if null passed in.
-	 *
-	 * @param timeZone
-	 *            a valid time zone, if null then defaults to "EST5EDT";
-	 * @return today's date in DateTime for the passed in timeZone
-	 */
-	public static DateTime nowUsingTimeZone(DateTimeZone timeZone) {
-		if (timeZone == null) {
-			timeZone = defaultTimeZone();
-		}
+    /**
+     * Returns today based on time zone; defaults timeZone to "EST5EDT" if null passed in.
+     *
+     * @param timeZone a valid time zone, if null then defaults to "EST5EDT";
+     * @return today's date in DateTime for the passed in timeZone
+     */
+    public static DateTime nowUsingTimeZone(DateTimeZone timeZone) {
+        if (timeZone == null) {
+            timeZone = defaultTimeZone();
+        }
 
-		return new DateTime(timeZone);
-	}
+        return new DateTime(timeZone);
+    }
 
-	public static DateTime forceParseStringToDateTime(String dateStr, String dateFormat) {
-		return new DateTime(forceParseStringToDate(dateStr, dateFormat));
-	}
+    public static DateTime forceParseStringToDateTime(String dateStr, String dateFormat) {
+        return new DateTime(forceParseStringToDate(dateStr, dateFormat));
+    }
 
-	public static  XMLGregorianCalendar forceParseStringToXMLGregorianCalendar(String dateStr, String dateFormat) {
-		return dateToXMLGregorianCal(forceParseStringToDate(dateStr, dateFormat));
-	}
+    public static XMLGregorianCalendar forceParseStringToXMLGregorianCalendar(String dateStr, String dateFormat) {
+        return dateToXMLGregorianCal(forceParseStringToDate(dateStr, dateFormat));
+    }
 
-	public static String formatDate(Date date, String format) {
-		if(date == null) {
-			return "";
-		}
+    public static String formatDate(Date date, String format) {
+        if (date == null) {
+            return "";
+        }
 
-		TimeZone timeZone = TimeZone.getTimeZone("America/Detroit");
+        TimeZone timeZone = TimeZone.getTimeZone("America/Detroit");
 
-		DateFormat dateFormat = new SimpleDateFormat(format);
-		dateFormat.setLenient(false);
-		dateFormat.setTimeZone(timeZone);
-		return dateFormat.format(date);
-	}
+        DateFormat dateFormat = new SimpleDateFormat(format);
+        dateFormat.setLenient(false);
+        dateFormat.setTimeZone(timeZone);
+        return dateFormat.format(date);
+    }
 
-	public static String formatDateTime(DateTime date, String format) {
-		if(date == null) {
-			return "";
-		}
+    public static String formatDateTime(DateTime date, String format) {
+        if (date == null) {
+            return "";
+        }
 
-		return formatDate(date.toDate(), format);
-	}
+        return formatDate(date.toDate(), format);
+    }
 
-	public static XMLGregorianCalendar dateToXMLGregorianCal(Date date) {
-		if(date == null) {
-			return  null;
-		}
+    public static XMLGregorianCalendar dateToXMLGregorianCal(Date date) {
+        if (date == null) {
+            return null;
+        }
 
-		TimeZone timeZone = TimeZone.getTimeZone("America/Detroit");
+        TimeZone timeZone = TimeZone.getTimeZone("America/Detroit");
 
-		GregorianCalendar gregorianCal = new GregorianCalendar(timeZone);
-		gregorianCal.setTime(date);
+        GregorianCalendar gregorianCal = new GregorianCalendar(timeZone);
+        gregorianCal.setTime(date);
 
-		try {
-			return DatatypeFactory.newInstance().newXMLGregorianCalendar(gregorianCal);
-		} catch (DatatypeConfigurationException e) {
-			return null;
-		}
-	}
+        try {
+            return DatatypeFactory.newInstance().newXMLGregorianCalendar(gregorianCal);
+        } catch (DatatypeConfigurationException e) {
+            return null;
+        }
+    }
 
-	public static XMLGregorianCalendar dateToXMLGregorianCalWithTimezone(Date date, TimeZone timezone) {
-		if(date == null) {
-			return  null;
-		}
+    public static XMLGregorianCalendar dateToXMLGregorianCalWithTimezone(Date date, TimeZone timezone) {
+        if (date == null) {
+            return null;
+        }
 
-		DateTimeZone dateTimeZone = DateTimeZone.forTimeZone(timezone);
+        DateTimeZone dateTimeZone = DateTimeZone.forTimeZone(timezone);
 
-		DateTime datetime = new DateTime(date.getTime(), dateTimeZone);
+        DateTime datetime = new DateTime(date.getTime(), dateTimeZone);
 
-		return dateTimeToXmlGregorianCalendar(datetime);
-	}
+        return dateTimeToXmlGregorianCalendar(datetime);
+    }
 
-	public static Date xmlGregorianCalToDate(XMLGregorianCalendar xmlGregCal) {
-		if(xmlGregCal == null) {
-			return null;
-		}
-		return xmlGregCal.toGregorianCalendar().getTime();
-	}
+    public static Date xmlGregorianCalToDate(XMLGregorianCalendar xmlGregCal) {
+        if (xmlGregCal == null) {
+            return null;
+        }
+        return xmlGregCal.toGregorianCalendar().getTime();
+    }
 
-	public static Boolean stringContains(String toCheckIn, String toCheckFor) {
-		if(toCheckIn == null || toCheckFor == null || toCheckFor.isEmpty()) {
-			return false;
-		}
+    public static Boolean stringContains(String toCheckIn, String toCheckFor) {
+        if (toCheckIn == null || toCheckFor == null || toCheckFor.isEmpty()) {
+            return false;
+        }
 
-		if(toCheckIn.isEmpty()) {
-			return true;
-		}
+        if (toCheckIn.isEmpty()) {
+            return true;
+        }
 
-		List<String> valuesForCheck = Arrays.asList(toCheckIn.split(","));
-		for(String value : valuesForCheck) {
-			if(value.trim().equalsIgnoreCase(toCheckFor.trim())) {
-				return true;
-			}
-		}
+        List<String> valuesForCheck = Arrays.asList(toCheckIn.split(","));
+        for (String value : valuesForCheck) {
+            if (value.trim().equalsIgnoreCase(toCheckFor.trim())) {
+                return true;
+            }
+        }
 
-		return false;
-	}
+        return false;
+    }
 
-	public static Boolean listContains(Collection<String> toCheckIn, String toCheckFor) {
-		for(String object : toCheckIn) {
-			if(object.equalsIgnoreCase(toCheckFor)) {
-				return true;
-			}
-		}
+    public static Boolean listContains(Collection<String> toCheckIn, String toCheckFor) {
+        for (String object : toCheckIn) {
+            if (object.equalsIgnoreCase(toCheckFor)) {
+                return true;
+            }
+        }
 
-		return false;
-	}
+        return false;
+    }
 
-	public static String arrayToString(String[] a, String separator) {
-		StringBuilder result = new StringBuilder();
-		if (a == null) {
-			return null;
-		} else if (a.length > 0) {
-			result.append(a[0]);
-			for (int i = 1; i < a.length; i++) {
-				result.append(separator);
-				result.append(a[i]);
-			}
-		}
+    public static String arrayToString(String[] a, String separator) {
+        StringBuilder result = new StringBuilder();
+        if (a == null) {
+            return null;
+        } else if (a.length > 0) {
+            result.append(a[0]);
+            for (int i = 1; i < a.length; i++) {
+                result.append(separator);
+                result.append(a[i]);
+            }
+        }
 
-		return result.toString();
-	}
+        return result.toString();
+    }
 
-	public static Boolean parseBoolean(String bool) {
-		if(bool == null || bool.isEmpty()) {
-			return false;
-		}
+    public static Boolean parseBoolean(String bool) {
+        if (bool == null || bool.isEmpty()) {
+            return false;
+        }
 
-		if(bool.equalsIgnoreCase(Boolean.TRUE.toString())) {
-			return true;
-		}
+        if (bool.equalsIgnoreCase(Boolean.TRUE.toString())) {
+            return true;
+        }
 
-		return false;
-	}
+        return false;
+    }
 
     public static String parseString(Object value) {
         return value == null ? "" : value.toString();
     }
 
-	public static DateTime xmlGregorianCalendarToDateTime(XMLGregorianCalendar calendar) {
-		if(calendar == null) {
-			return  null;
-		}
+    public static DateTime xmlGregorianCalendarToDateTime(XMLGregorianCalendar calendar) {
+        if (calendar == null) {
+            return null;
+        }
 
-		DateTimeZone timeZone = DateTimeZone.forTimeZone(calendar.getTimeZone(0));
+        DateTimeZone timeZone = DateTimeZone.forTimeZone(calendar.getTimeZone(0));
 
-		DateTime dateTime = new DateTime(calendar.toGregorianCalendar().getTime(), timeZone);
+        DateTime dateTime = new DateTime(calendar.toGregorianCalendar().getTime(), timeZone);
 
-		return dateTime;
-	}
+        return dateTime;
+    }
 
-	public static XMLGregorianCalendar dateTimeToXmlGregorianCalendar(DateTime dateTime) {
-		if(dateTime == null) {
-			return  null;
-		}
+    public static XMLGregorianCalendar dateTimeToXmlGregorianCalendar(DateTime dateTime) {
+        if (dateTime == null) {
+            return null;
+        }
 
-		GregorianCalendar gregorianCalendar = new GregorianCalendar();
-		gregorianCalendar.setTimeInMillis(dateTime.toLocalDateTime().toDate().getTime());
+        GregorianCalendar gregorianCalendar = new GregorianCalendar();
+        gregorianCalendar.setTimeInMillis(dateTime.toLocalDateTime().toDate().getTime());
 
-		try {
-			return DatatypeFactory.newInstance().newXMLGregorianCalendar(gregorianCalendar);
-		} catch (DatatypeConfigurationException e) {
-			return null;
-		}
-	}
+        try {
+            return DatatypeFactory.newInstance().newXMLGregorianCalendar(gregorianCalendar);
+        } catch (DatatypeConfigurationException e) {
+            return null;
+        }
+    }
 
-	public static String createEntireInStatement(Collection<String> values) {
-		return createEntireInStatement("", values);
-	}
+    public static String createEntireInStatement(Collection<String> values) {
+        return createEntireInStatement("", values);
+    }
 
-	public static String createEntireInStatement(String field, Collection<String> values) {
-		String commaSeparated = values.parallelStream().map( value -> {
-			return "'" + value + "'";
-		}).collect(Collectors.joining(","));
+    public static String createEntireInStatement(String field, Collection<String> values) {
+        String commaSeparated = values.parallelStream().map(value -> {
+            return "'" + value + "'";
+        }).collect(Collectors.joining(","));
 
-		return field + " IN (" + commaSeparated + ")";
-	}
+        return field + " IN (" + commaSeparated + ")";
+    }
 
     public static Integer nullCheck(Integer value) {
         return nullCheck(value, 0);
@@ -660,9 +661,9 @@ public class Utility {
         A result = collect.supplier().get();
 
         queryForAll(type, where, fields, (batch) -> {
-        	A batchResult = collect.supplier().get();
+            A batchResult = collect.supplier().get();
 
-            batch.parallelStream().forEach( entity -> {
+            batch.parallelStream().forEach(entity -> {
                 collect.accumulator().accept(batchResult, entity);
             });
 
@@ -676,9 +677,9 @@ public class Utility {
         A result = collect.supplier().get();
 
         queryForAll(type, where, fields, (batch) -> {
-        	A batchResult = collect.supplier().get();
+            A batchResult = collect.supplier().get();
 
-            batch.forEach( entity -> {
+            batch.forEach(entity -> {
                 collect.accumulator().accept(batchResult, entity);
             });
 
@@ -744,32 +745,32 @@ public class Utility {
         A result = collect.supplier().get();
 
         searchForAll(type, where, fields, (batch) -> {
-	        A batchResult = collect.supplier().get();
+            A batchResult = collect.supplier().get();
 
-	        batch.parallelStream().forEach( entity -> {
-		        collect.accumulator().accept(batchResult, entity);
-	        });
+            batch.parallelStream().forEach(entity -> {
+                collect.accumulator().accept(batchResult, entity);
+            });
 
-	        collect.combiner().apply(result, batchResult);
+            collect.combiner().apply(result, batchResult);
         });
 
-	    return collect.finisher().apply(result);
+        return collect.finisher().apply(result);
     }
 
     public static <T extends SearchEntity, A, R> R sequentialSearchAndCollectAll(Class<T> type, String where, Set<String> fields, Collector<T, A, R> collect) {
         A result = collect.supplier().get();
 
         searchForAll(type, where, fields, (batch) -> {
-	        A batchResult = collect.supplier().get();
+            A batchResult = collect.supplier().get();
 
-	        batch.forEach( entity -> {
-		        collect.accumulator().accept(batchResult, entity);
-	        });
+            batch.forEach(entity -> {
+                collect.accumulator().accept(batchResult, entity);
+            });
 
-	        collect.combiner().apply(result, batchResult);
+            collect.combiner().apply(result, batchResult);
         });
 
-	    return collect.finisher().apply(result);
+        return collect.finisher().apply(result);
     }
 
     private static <T extends QueryEntity> void queryForAll(Class<T> type, String where, Set<String> fields, Consumer<List<T>> process) {
@@ -788,7 +789,7 @@ public class Utility {
 
         process.accept(result.getData());
 
-        if(result.getStart() + result.getCount() < result.getTotal()) {
+        if (result.getStart() + result.getCount() < result.getTotal()) {
             queryForAll(type, where, fields, process, result.getStart() + result.getCount());
         }
     }
@@ -808,7 +809,7 @@ public class Utility {
 
         process.accept(result.getData());
 
-        if(result.getStart() + result.getCount() < result.getTotal()) {
+        if (result.getStart() + result.getCount() < result.getTotal()) {
             searchForAll(type, where, fields, process, result.getStart() + result.getCount());
         }
     }
@@ -816,7 +817,7 @@ public class Utility {
     private static final int BATCH_SIZE = 200;
 
     private static synchronized BullhornData getBullhornData() {
-        if(BULLHORN_DATA == null) {
+        if (BULLHORN_DATA == null) {
             BULLHORN_DATA = AppContext.getApplicationContext().getBean(BullhornData.class);
         }
 

--- a/src/main/java/com/client/core/base/util/Utility.java
+++ b/src/main/java/com/client/core/base/util/Utility.java
@@ -785,6 +785,7 @@ public class Utility {
         QueryParams params = ParamFactory.queryParams();
         params.setStart(start);
         params.setCount(BATCH_SIZE);
+        params.setOrderBy("id");
         params.setShowTotalMatched(true);
 
         ListWrapper<T> result = bullhornData.query(type, where, fields, params);
@@ -806,6 +807,7 @@ public class Utility {
         SearchParams params = ParamFactory.searchParams();
         params.setStart(start);
         params.setCount(BATCH_SIZE);
+        params.setSort("id");
 
         ListWrapper<T> result = bullhornData.search(type, where, fields, params);
 

--- a/src/main/java/com/client/core/base/util/Utility.java
+++ b/src/main/java/com/client/core/base/util/Utility.java
@@ -185,8 +185,10 @@ public class Utility {
             String newString = StringUtils.defaultIfBlank((String) newValue, "");
 
             return !oldString.equals(newString);
-        } else if (oldValue instanceof Boolean || oldValue instanceof Integer) {
+        } else if (oldValue instanceof Boolean) {
             return oldValue != newValue;
+        } else if (oldValue instanceof Integer) {
+            return !oldValue.equals(newValue);
         } else if (oldValue instanceof BigDecimal) {
             return ((BigDecimal) oldValue).compareTo((BigDecimal) newValue) != 0;
         } else if (oldValue instanceof DateTime) {


### PR DESCRIPTION
```
} else if (oldValue instanceof Boolean || oldValue instanceof Integer) {
            return oldValue != newValue;
```

In the above case, JVM uses the value of `oldValue` and `newValue` from the cached pool and returns the same object instance(therefore memory address) of integer object and we get both are equal. It's an optimization JVM does for certain range values.

If the value not in the -128 to 127 range it will not work, proper way:
```
oldValue.equals(newValue)
```