### PR TITLE
Adding early return to SessionFilter + Removing error handler + upgrading to sdk-rest v2.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>com.bullhorn</groupId>
             <artifactId>sdk-rest</artifactId>
-            <version>2.1.1</version>
+            <version>2.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>com.client</groupId>
     <artifactId>starter-kit-spring-maven</artifactId>
-    <version>6.0.0</version>
+    <version>6.0.1</version>
     <packaging>war</packaging>
     <name>Bullhorn Spring Boot Starter Kit</name>
     <description>Starter kit for Bullhorn Professional Services</description>
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>com.bullhorn</groupId>
             <artifactId>sdk-rest</artifactId>
-            <version>2.0.1</version>
+            <version>2.1.1</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/client/SessionFilter.java
+++ b/src/main/java/com/client/SessionFilter.java
@@ -45,10 +45,11 @@ public class SessionFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 		if (EXCLUDED_URL_PATHS.contains(request.getServletPath())) {
 			filterChain.doFilter(request, response);
+			return;
 		}
+
 		final HttpSession session = getSession(request);
 		final String apiKey = getApiKeyFromRequest(request);
-
 		final String previouslyAuthorizedApiKeyEncrypted = getApiKeyFromSession(session);
 		final String url = request.getRequestURL().toString();
 
@@ -64,7 +65,7 @@ public class SessionFilter extends OncePerRequestFilter {
 			encryptApiKeyAndAddToSession(session, apiKey);
 		}
 
-		if (allowIn == false) {
+		if (!allowIn) {
 			log.info("Attempt to get to page: " + url + " was blocked in the SessionFilter. Returning 401 unauthorized response.");
 
 			response.sendError(HttpStatus.UNAUTHORIZED.value());
@@ -126,11 +127,7 @@ public class SessionFilter extends OncePerRequestFilter {
 			apiKey = "";
 		}
 
-		if (apiKey.equals(this.apiKey)) {
-			return true;
-		}
-
-		return false;
+		return apiKey.equals(this.apiKey);
 	}
 
     public String getSessionStoredApiKeyName() {

--- a/src/main/java/com/client/config/GeneralConfig.java
+++ b/src/main/java/com/client/config/GeneralConfig.java
@@ -3,14 +3,11 @@ package com.client.config;
 import com.bullhornsdk.data.api.BullhornData;
 import com.bullhornsdk.data.api.BullhornRestCredentials;
 import com.bullhornsdk.data.api.StandardBullhornData;
-import com.bullhornsdk.data.exception.CustomResponseErrorHandler;
 import com.client.ApplicationSettings;
 
 import com.client.core.base.tools.context.CustomReloadableResourceBundleMessageSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.client.ResponseErrorHandler;
-import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.commons.CommonsMultipartResolver;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.LocaleResolver;
@@ -38,18 +35,6 @@ public class GeneralConfig {
     @Bean
     public BullhornData bullhornData(BullhornRestCredentials bullhornRestCredentials) {
         return new StandardBullhornData(bullhornRestCredentials);
-    }
-
-    @Bean
-    public RestTemplate restTemplate(ResponseErrorHandler responseErrorHandler) {
-        RestTemplate restTemplate = new RestTemplate();
-        restTemplate.setErrorHandler(responseErrorHandler);
-        return restTemplate;
-    }
-
-    @Bean
-    public CustomResponseErrorHandler customResponseErrorHandler() {
-        return new CustomResponseErrorHandler();
     }
 
     @Bean

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -53,7 +53,7 @@ hibernate.showSql=true
 hibernate.generateDdl=true
 
 rest.prefix.core=/main/resttrigger
-rest.prefix.custom=/custom/resttrigger
+rest.prefix.custom=/custom
 
 # Example custom subscriptions
 # scheduledtasks.customSubscriptions.standardSubscription=0 */5 * * * ?


### PR DESCRIPTION
- Bugs found that presented issues inside of the SessionFilter have been fixed.
- Springboot with JDK 17 creates its own RestTemplate bean. Configuring a RestTemplate just to attach its own DefaultResponseHandler is dubious.
- Upgrading to com.bullhorn:sdk-rest:2.2.0