### PR TITLE
REST Trigger Enhancements

### DIFF
--- a/src/main/java/com/client/core/base/tools/entitychanger/impl/StandardEntityChanger.java
+++ b/src/main/java/com/client/core/base/tools/entitychanger/impl/StandardEntityChanger.java
@@ -1,5 +1,6 @@
 package com.client.core.base.tools.entitychanger.impl;
 
+import com.bullhornsdk.data.model.entity.core.type.AbstractEntity;
 import com.bullhornsdk.data.model.entity.core.type.BullhornEntity;
 import com.bullhornsdk.data.model.entity.embedded.Address;
 import com.client.core.base.tools.entitychanger.EntityChanger;
@@ -65,6 +66,11 @@ public class StandardEntityChanger implements EntityChanger {
         try {
             PropertyDescriptor propertyDescriptor = BeanUtils.getPropertyDescriptor(target.getClass(), finalField);
             if (propertyDescriptor == null) {
+                if (entity instanceof AbstractEntity) {
+                    ((AbstractEntity) entity).getAdditionalProperties().put(finalField, value);
+                    return entity;
+                }
+
                 throw new RuntimeException("Could not find property descriptor for " + finalField);
             }
             Class<?> fieldType = propertyDescriptor.getPropertyType();

--- a/src/test/java/com/client/core/base/tools/entitychanger/impl/StandardEntityChangerTest.java
+++ b/src/test/java/com/client/core/base/tools/entitychanger/impl/StandardEntityChangerTest.java
@@ -226,10 +226,10 @@ public class StandardEntityChangerTest {
     }
 
     @Test
-    public void setValueFailsIfPropertyDoesNotExist() {
+    public void setValueFailsIfPropertyDoesNotExistAndEntityDoesntHaveAdditionalProperties() {
         EntityChanger entityChanger = new StandardEntityChanger();
         Assertions.assertThrows(RuntimeException.class, () ->
-                entityChanger.setField(candidate, "thisPropertyDoesNotExist", "customValue")
+                entityChanger.setField(testBullhornEntity, "thisPropertyDoesNotExist", "customValue")
         );
     }
 
@@ -247,6 +247,16 @@ public class StandardEntityChangerTest {
         Assertions.assertThrows(RuntimeException.class, () ->
                 entityChanger.setField(testBullhornEntity, "fieldWithNoGetter.length", 50)
         );
+    }
+
+    @Test
+    public void setValueAddsUnknownPropertiesToAdditionalPropertiesIfPossible() {
+        EntityChanger entityChanger = new StandardEntityChanger();
+        entityChanger.setField(candidate, "candidateMissingField", "Test Value");
+        assertEquals("Test Value", candidate.getAdditionalProperties().get("candidateMissingField"));
+        // Simulating assigning a missing relationship as a map
+        entityChanger.setField(candidate, "missingRelation", Map.of("id", 10));
+        assertEquals(10, ((Map) candidate.getAdditionalProperties().get("missingRelation")).get("id"));
     }
 
     @SuppressWarnings("ALL")

--- a/src/test/java/com/client/core/base/util/UtilityTest.java
+++ b/src/test/java/com/client/core/base/util/UtilityTest.java
@@ -1,0 +1,28 @@
+package com.client.core.base.util;
+
+import com.google.common.collect.Sets;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class UtilityTest {
+    @Test
+    public void testExtractAssociationFieldsFromParentWorksWithNoNestedFields() {
+        Set<String> extracted = Utility.extractAssociationFieldsFromParent(Sets.newHashSet("id", "categories"), "categories");
+        assertEquals(extracted, Sets.newHashSet("id"));
+    }
+
+    @Test
+    public void testExtractAssociationFieldsFromParentWorksWithNestedFields() {
+        Set<String> extracted = Utility.extractAssociationFieldsFromParent(Sets.newHashSet("id", "categories(specialties(id,name),id,name)"), "categories");
+        assertEquals(extracted, Sets.newHashSet("specialties(id,name)", "id", "name"));
+    }
+
+    @Test
+    public void testExtractAssociationFieldsFromParentWorksWithMissingFields() {
+        Set<String> extracted = Utility.extractAssociationFieldsFromParent(Sets.newHashSet("id", "categories"), "specialties");
+        assertEquals(extracted, Sets.newHashSet("id"));
+    }
+}


### PR DESCRIPTION
Adding some enhancements to better handle errors that may rise from using REST Triggers on new entities. Namely,
1. Fields that are yet unsupported by the REST SDK that come into the payload raise an exception in the `StandardEntityChanger`, because it doesn't know how to handle those.
2. Fields that are supported by the REST SDK, but come in an association-operation format. This is very common with associated entities. `TriggerUtil` doesn't currently support extracting the IDs from the `replaceAll` array, and will utimately fail in `StandardEntityChanger`, and the value in any REST Trigger that calls `getNewEntity` will be empty, despite the developer expectation being the field included via the related entity fields `Map`.

The proposed fixes for this issues are:
1. Enhancing `StandardEntityChanger.setField` to check if the entity it's trying to set a field for supports the `additionalProperties` map that's available for all `AbstractEntities`, effectively covering all basic Bullhorn entities
2. Enhancing `TriggerUtil` to check for the presence of a `Map` with a `replaceAll` key, querying the necessary data using the `AssociationField` (if any). the fields used to query the fields of the association will be extracted from the final list of related entity fields built from `WorkflowAction`s