### PR TITLE
Fix StandardEntityChanger to support String casting when possible

### DIFF
--- a/src/main/java/com/client/core/base/tools/entitychanger/impl/StandardEntityChanger.java
+++ b/src/main/java/com/client/core/base/tools/entitychanger/impl/StandardEntityChanger.java
@@ -66,8 +66,8 @@ public class StandardEntityChanger implements EntityChanger {
         try {
             PropertyDescriptor propertyDescriptor = BeanUtils.getPropertyDescriptor(target.getClass(), finalField);
             if (propertyDescriptor == null) {
-                if (entity instanceof AbstractEntity) {
-                    ((AbstractEntity) entity).getAdditionalProperties().put(finalField, value);
+                if (target instanceof AbstractEntity) {
+                    ((AbstractEntity) target).getAdditionalProperties().put(finalField, value);
                     return entity;
                 }
 

--- a/src/main/java/com/client/core/base/tools/entitychanger/impl/StandardEntityChanger.java
+++ b/src/main/java/com/client/core/base/tools/entitychanger/impl/StandardEntityChanger.java
@@ -103,6 +103,8 @@ public class StandardEntityChanger implements EntityChanger {
                         propertyDescriptor.getWriteMethod().invoke(target, asType(value, BigDecimal.class));
                     } else if (Boolean.class.equals(fieldType)) {
                         propertyDescriptor.getWriteMethod().invoke(target, asType(value, Boolean.class));
+                    } else if (String.class.equals(fieldType)) {
+                        propertyDescriptor.getWriteMethod().invoke(target, asType(value, String.class));
                     } else {
                         log.error("Error setting field " + finalField + " to value " + value, e);
                     }

--- a/src/main/java/com/client/core/base/tools/entitychanger/impl/StandardEntityChanger.java
+++ b/src/main/java/com/client/core/base/tools/entitychanger/impl/StandardEntityChanger.java
@@ -97,16 +97,8 @@ public class StandardEntityChanger implements EntityChanger {
                         BullhornEntity bullhornEntity = (BullhornEntity) fieldType.getDeclaredConstructor().newInstance();
                         bullhornEntity.setId((Integer) value);
                         propertyDescriptor.getWriteMethod().invoke(target, bullhornEntity);
-                    } else if (Integer.class.equals(fieldType)) {
-                        propertyDescriptor.getWriteMethod().invoke(target, asType(value, Integer.class));
-                    } else if (BigDecimal.class.equals(fieldType)) {
-                        propertyDescriptor.getWriteMethod().invoke(target, asType(value, BigDecimal.class));
-                    } else if (Boolean.class.equals(fieldType)) {
-                        propertyDescriptor.getWriteMethod().invoke(target, asType(value, Boolean.class));
-                    } else if (String.class.equals(fieldType)) {
-                        propertyDescriptor.getWriteMethod().invoke(target, asType(value, String.class));
                     } else {
-                        log.error("Error setting field " + finalField + " to value " + value, e);
+                        propertyDescriptor.getWriteMethod().invoke(target, asType(value, fieldType));
                     }
                 }
             }

--- a/src/main/java/com/client/core/base/tools/entitychanger/impl/StandardEntityChanger.java
+++ b/src/main/java/com/client/core/base/tools/entitychanger/impl/StandardEntityChanger.java
@@ -106,7 +106,7 @@ public class StandardEntityChanger implements EntityChanger {
                             ((AbstractEntity) entity).getAdditionalProperties().put(finalField, value);
                             log.warn("Saved {} to entity's additionalProperties", finalField);
                         } else {
-                            log.warn("Entity does not support additionalProperties so couldn't save {}", finalField);
+                            log.error("Entity does not support additionalProperties so couldn't save {}", finalField);
                         }
                     }
                 }

--- a/src/main/java/com/client/core/base/tools/entitychanger/impl/StandardEntityChanger.java
+++ b/src/main/java/com/client/core/base/tools/entitychanger/impl/StandardEntityChanger.java
@@ -91,9 +91,7 @@ public class StandardEntityChanger implements EntityChanger {
                 try {
                     propertyDescriptor.getWriteMethod().invoke(target, value);
                 } catch (IllegalAccessException | InvocationTargetException | IllegalArgumentException e) {
-                    if (DateTime.class.equals(fieldType)) {
-                        propertyDescriptor.getWriteMethod().invoke(target, asType(value, DateTime.class));
-                    } else if (BullhornEntity.class.isAssignableFrom(fieldType)) {
+                    if (BullhornEntity.class.isAssignableFrom(fieldType)) {
                         BullhornEntity bullhornEntity = (BullhornEntity) fieldType.getDeclaredConstructor().newInstance();
                         bullhornEntity.setId((Integer) value);
                         propertyDescriptor.getWriteMethod().invoke(target, bullhornEntity);

--- a/src/test/java/com/client/core/base/tools/entitychanger/impl/StandardEntityChangerTest.java
+++ b/src/test/java/com/client/core/base/tools/entitychanger/impl/StandardEntityChangerTest.java
@@ -259,6 +259,20 @@ public class StandardEntityChangerTest {
         assertEquals(10, ((Map) candidate.getAdditionalProperties().get("missingRelation")).get("id"));
     }
 
+    @Test
+    public void setFieldCastsIntegerToString() {
+        EntityChanger entityChanger = new StandardEntityChanger();
+        entityChanger.setField(candidate, "customText1", 10);
+        assertEquals(candidate.getCustomText1(), "10");
+    }
+
+    @Test
+    public void setFieldCastsDoubleToString() {
+        EntityChanger entityChanger = new StandardEntityChanger();
+        entityChanger.setField(candidate, "customText1", 10.5d);
+        assertEquals(candidate.getCustomText1(), "10.5");
+    }
+
     @SuppressWarnings("ALL")
     static class TestBullhornEntity implements BullhornEntity {
         private Integer id;

--- a/src/test/java/com/client/core/base/tools/entitychanger/impl/StandardEntityChangerTest.java
+++ b/src/test/java/com/client/core/base/tools/entitychanger/impl/StandardEntityChangerTest.java
@@ -7,8 +7,10 @@ import com.bullhornsdk.data.model.entity.core.type.BullhornEntity;
 import com.bullhornsdk.data.model.entity.embedded.Address;
 import com.client.core.base.tools.entitychanger.EntityChanger;
 import com.google.common.collect.ImmutableMap;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 import org.joda.time.DateTime;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,16 +18,14 @@ import org.junit.jupiter.api.Test;
 import java.math.BigDecimal;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 
 public class StandardEntityChangerTest {
     private Candidate candidate;
     private Candidate emptyCandidate;
     private TestBullhornEntity testBullhornEntity;
+    private NoAdditionalProperties noAdditionalProperties;
 
     @BeforeEach
     public void setUp() {
@@ -40,6 +40,7 @@ public class StandardEntityChangerTest {
         emptyCandidate = new Candidate();
 
         testBullhornEntity = new TestBullhornEntity();
+        noAdditionalProperties = new NoAdditionalProperties();
     }
 
     private Address makeAddress() {
@@ -230,7 +231,7 @@ public class StandardEntityChangerTest {
     public void setValueFailsIfPropertyDoesNotExistAndEntityDoesntHaveAdditionalProperties() {
         EntityChanger entityChanger = new StandardEntityChanger();
         Assertions.assertThrows(RuntimeException.class, () ->
-                entityChanger.setField(testBullhornEntity, "thisPropertyDoesNotExist", "customValue")
+                entityChanger.setField(noAdditionalProperties, "thisPropertyDoesNotExist", "customValue")
         );
     }
 
@@ -251,11 +252,15 @@ public class StandardEntityChangerTest {
     }
 
     @Test
-    public void setValueAddsUnknownPropertiesToAdditionalPropertiesIfPossible() {
+    public void setFieldAddsUnknownPropertiesToAdditionalPropertiesIfPossible() {
         EntityChanger entityChanger = new StandardEntityChanger();
         entityChanger.setField(candidate, "candidateMissingField", "Test Value");
         assertEquals("Test Value", candidate.getAdditionalProperties().get("candidateMissingField"));
-        // Simulating assigning a missing relationship as a map
+    }
+
+    @Test
+    public void setFieldAddsUnknownRelationshipToAdditionalPropertiesIfPossible() {
+        EntityChanger entityChanger = new StandardEntityChanger();
         entityChanger.setField(candidate, "missingRelation", Map.of("id", 10));
         assertEquals(10, ((Map) candidate.getAdditionalProperties().get("missingRelation")).get("id"));
     }
@@ -279,6 +284,24 @@ public class StandardEntityChangerTest {
         EntityChanger entityChanger = new StandardEntityChanger();
         entityChanger.setField(testBullhornEntity, "simpleStringContainer", "Test");
         assertEquals("Test", testBullhornEntity.getAdditionalProperties().get("simpleStringContainer"));
+    }
+
+    @Test
+    public void setFieldSavesUnknownPropertiesOfNestedEntitiesToAdditionalPropertiesIfAvailable() {
+        EntityChanger entityChanger = new StandardEntityChanger();
+        ImmutableMap<Object, Object> map = ImmutableMap.builder()
+                .put("id", "Test").build();
+        entityChanger.setField(testBullhornEntity, "simpleStringContainer", map);
+        assertNotNull(testBullhornEntity.getSimpleStringContainer());
+        assertEquals("Test", testBullhornEntity.getSimpleStringContainer().getAdditionalProperties().get("id"));
+    }
+
+    @Test
+    public void setFieldSavesUnknownNestedEntityPropertiesToAdditionalPropertiesIfAvailable() {
+        EntityChanger entityChanger = new StandardEntityChanger();
+        entityChanger.setField(testBullhornEntity, "simpleStringContainer.unknown", "Test");
+        assertNotNull(testBullhornEntity.getSimpleStringContainer());
+        assertEquals("Test", testBullhornEntity.getSimpleStringContainer().getAdditionalProperties().get("unknown"));
     }
 
     @SuppressWarnings("ALL")
@@ -324,5 +347,14 @@ public class StandardEntityChangerTest {
         }
     }
 
-    record SimpleStringContainer(String string) {}
+    @Data
+    static class NoAdditionalProperties {
+        String property;
+    }
+    @EqualsAndHashCode(callSuper = true)
+    @Data
+    @NoArgsConstructor
+    static class SimpleStringContainer extends AbstractEntity {
+        String string;
+    }
 }

--- a/src/test/java/com/client/core/base/tools/entitychanger/impl/StandardEntityChangerTest.java
+++ b/src/test/java/com/client/core/base/tools/entitychanger/impl/StandardEntityChangerTest.java
@@ -2,6 +2,7 @@ package com.client.core.base.tools.entitychanger.impl;
 
 import com.bullhornsdk.data.model.entity.core.standard.Candidate;
 import com.bullhornsdk.data.model.entity.core.standard.CorporateUser;
+import com.bullhornsdk.data.model.entity.core.type.AbstractEntity;
 import com.bullhornsdk.data.model.entity.core.type.BullhornEntity;
 import com.bullhornsdk.data.model.entity.embedded.Address;
 import com.client.core.base.tools.entitychanger.EntityChanger;
@@ -273,14 +274,21 @@ public class StandardEntityChangerTest {
         assertEquals(candidate.getCustomText1(), "10.5");
     }
 
+    @Test
+    public void setFieldSavesFailedCastsToAdditionalPropertiesIfAvailable() {
+        EntityChanger entityChanger = new StandardEntityChanger();
+        entityChanger.setField(testBullhornEntity, "simpleStringContainer", "Test");
+        assertEquals("Test", testBullhornEntity.getAdditionalProperties().get("simpleStringContainer"));
+    }
+
     @SuppressWarnings("ALL")
-    static class TestBullhornEntity implements BullhornEntity {
+    static class TestBullhornEntity extends AbstractEntity implements BullhornEntity {
         private Integer id;
         private String fieldWithNoGetter;
         private String fieldWithNoSetter = "value";
 
         private String invisibleProperty;
-
+        private SimpleStringContainer simpleStringContainer;
         @Override
         public Integer getId() {
             return this.id;
@@ -306,5 +314,15 @@ public class StandardEntityChangerTest {
         private void setInvisibleProperty(String invisibleProperty) {
             this.invisibleProperty = invisibleProperty;
         }
+
+        public SimpleStringContainer getSimpleStringContainer() {
+            return simpleStringContainer;
+        }
+
+        public void setSimpleStringContainer(SimpleStringContainer simpleStringContainer) {
+            this.simpleStringContainer = simpleStringContainer;
+        }
     }
+
+    record SimpleStringContainer(String string) {}
 }


### PR DESCRIPTION
Currently, the `StandardEntityChanger` will fail to set text fields if the incoming parameter is not of `String` type. This PR fixes this to at least guarantee `Integer`/`Double` cast support, however every data type should be cast-able to `String` via the `Obejct.toString()` method.