### PR TITLE
SOLEN-8047: remove specific version from MySQLDialect

### DIFF
--- a/src/main/java/com/client/ApplicationSettings.java
+++ b/src/main/java/com/client/ApplicationSettings.java
@@ -33,6 +33,7 @@ public record ApplicationSettings(
 
     public record Hibernate(
         boolean showSql,
-        boolean generateDdl
+        boolean generateDdl,
+        String dialect
     ) {}
 }

--- a/src/main/java/com/client/config/JpaConfig.java
+++ b/src/main/java/com/client/config/JpaConfig.java
@@ -20,7 +20,7 @@ public class JpaConfig {
     @Bean
     public LocalContainerEntityManagerFactoryBean entityManagerFactory(ApplicationSettings appSettings, DataSource dataSource) {
         HibernateJpaVendorAdapter hibernateJpaVendorAdapter = new HibernateJpaVendorAdapter();
-        hibernateJpaVendorAdapter.setDatabasePlatform("org.hibernate.dialect.MySQLDialect");
+        hibernateJpaVendorAdapter.setDatabasePlatform(appSettings.hibernate().dialect());
         hibernateJpaVendorAdapter.setShowSql(appSettings.hibernate().showSql());
         hibernateJpaVendorAdapter.setGenerateDdl(appSettings.hibernate().generateDdl());
 

--- a/src/main/java/com/client/config/JpaConfig.java
+++ b/src/main/java/com/client/config/JpaConfig.java
@@ -20,7 +20,7 @@ public class JpaConfig {
     @Bean
     public LocalContainerEntityManagerFactoryBean entityManagerFactory(ApplicationSettings appSettings, DataSource dataSource) {
         HibernateJpaVendorAdapter hibernateJpaVendorAdapter = new HibernateJpaVendorAdapter();
-        hibernateJpaVendorAdapter.setDatabasePlatform("org.hibernate.dialect.MySQL5Dialect");
+        hibernateJpaVendorAdapter.setDatabasePlatform("org.hibernate.dialect.MySQLDialect");
         hibernateJpaVendorAdapter.setShowSql(appSettings.hibernate().showSql());
         hibernateJpaVendorAdapter.setGenerateDdl(appSettings.hibernate().generateDdl());
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -45,6 +45,7 @@ rest.sessionMinutesToLive=1400
 ## Hibernate configs
 hibernate.showSql=true
 hibernate.generateDdl=true
+hibernate.dialect=org.hibernate.dialect.MySQLDialect
 
 rest.prefix.core=/main/resttrigger
 rest.prefix.custom=/custom


### PR DESCRIPTION
For non Bullhorn projects. Remove specific version so that it automatically determines whether it should use mysql5 or 8 depending on what dependencies are set up for the project.